### PR TITLE
ROBUST-REDIS-LOCK reconstruct-early-pw-monkeypatching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
   - ruby-1.9.3
   - ruby-2.0.0
   - ruby-2.1.0
+  - ruby-2.3.7
+  - ruby-2.4.4
+  - ruby-2.5.1
   - jruby-head
 services:
   - redis-server

--- a/robust-redis-lock.gemspec
+++ b/robust-redis-lock.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
   s.summary     = "Robust redis lock"
   s.description = "Robust redis lock"
 
-  s.add_dependency "redis",         ">= 3.0.0"
+  s.add_dependency "redis",                ">= 3.0.0"
+  s.add_dependency "redis-script_manager", "~> 0.0.2"
 
   s.files        = Dir["lib/**/*"]
   s.require_path = 'lib'


### PR DESCRIPTION
PR for `robust-redis-lock`.

In 2015 we took a dependency on `robust-redis-lock` and then I monkey-patched it.

This PR reconstructs the early history of Prosperworks monkey-patches as a fork on `robust-redis-lock`.