### PR TITLE
ROBUST-REDIS-LOCK pw-monkeypatching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
   - ruby-1.9.3
   - ruby-2.0.0
   - ruby-2.1.0
+  - ruby-2.3.7
+  - ruby-2.4.4
+  - ruby-2.5.1
   - jruby-head
 services:
   - redis-server

--- a/robust-redis-lock.gemspec
+++ b/robust-redis-lock.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
   s.summary     = "Robust redis lock"
   s.description = "Robust redis lock"
 
-  s.add_dependency "redis",         ">= 3.0.0"
+  s.add_dependency "redis",                ">= 3.0.0"
+  s.add_dependency "redis-script_manager", "~> 0.0.2"
 
   s.files        = Dir["lib/**/*"]
   s.require_path = 'lib'


### PR DESCRIPTION
PR for `robust-redis-lock`.

In 2015 we took a dependency on `robust-redis-lock` and then I monkey-patched it.

This PR reconstructs the early history of Prosperworks monkey-patches as a fork on `robust-redis-lock`.  Those monkey-patches eliminated the use of the `key_group` feature.

This PR also goes further, doing some changes new in 2019-02-26.  When RedisLabs tried to sync from our ali-staging RLEC cluster in AWS/us-east-1 into a new cluster in GCP/us-east4, their Syncer process ran into a CROSSSLOT error trying to replicate the net effects of these Lua scripts.
```
# Lua which runs on Redis
local key = KEYS[1]
...
local token_key = 'redis:lock:token'
local prev_expires_at = tonumber(redis.call('hget', key, 'expires_at'))
if prev_expires_at and prev_expires_at > now then
  return {'locked', nil, nil}
 end
local next_token = redis.call('incr', token_key) -- PROBLEM! Talk to key not in KEYS[]!
```

ALI will end up using this version in https://github.com/ProsperWorks/ALI/pull/12147, where I also clean out the monkey-patching.