### PR TITLE
ROBUST-REDIS-LOCK cut-has_rdoc

### DIFF
--- a/robust-redis-lock.gemspec
+++ b/robust-redis-lock.gemspec
@@ -19,5 +19,4 @@ Gem::Specification.new do |s|
 
   s.files        = Dir["lib/**/*"]
   s.require_path = 'lib'
-  s.has_rdoc     = false
 end


### PR DESCRIPTION
PR for `robust-redis-lock`.

When pulling this project into ALI, I noticed the warning:
```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /Users/jhw/robust-redis-lock/robust-redis-lock.gemspec:22.
```
Defensively, I am removing the offending line before the ALI build suddenly stops working.

The docs say https://www.rubydoc.info/github/rubygems/rubygems/Gem%2FSpecification:has_rdoc:
> `Method: Gem::Specification#has_rdoc`
> Defined in:
> lib/rubygems/specification.rb
> permalink `#has_rdoc` ⇒ `Object`
> Also known as: `has_rdoc?`
> Deprecated and ignored, defaults to `true`.
> 
> Formerly used to indicate this gem was RDoc-capable.
